### PR TITLE
fixade felskrivning i packages och inkluderade en ny fil i gitignore

### DIFF
--- a/jobads_dbt/.gitignore
+++ b/jobads_dbt/.gitignore
@@ -2,3 +2,4 @@
 target/
 dbt_packages/
 logs/
+package-lock.yml

--- a/jobads_dbt/packages.yml
+++ b/jobads_dbt/packages.yml
@@ -1,6 +1,5 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.2.0
-packages:
   - package: calogica/dbt_expectations
     version: 0.10.3


### PR DESCRIPTION
Råkade a lagt in två "headers" i filen vilket gjorde att endast ett package lästes in när dbt deps kördes. Ändrade nu så att detta inte händer. Gjorde även en git ignore på packages-lock.yml då denna fil är en typ av log som skapas när dbt deps körs så jag anser att det är bättre om denna inte flyter runt i git projektet